### PR TITLE
Fixes compiler warning in Xcode 9 for prototype block

### DIFF
--- a/Library/JCNotificationBanner.h
+++ b/Library/JCNotificationBanner.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef void (^JCNotificationBannerTapHandlingBlock)();
+typedef void (^JCNotificationBannerTapHandlingBlock)(void);
 
 @interface JCNotificationBanner : NSObject
 


### PR DESCRIPTION
his block declaration is not a prototype